### PR TITLE
Update SHMEM README and fix int overflow at scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ implementation.
 |             | in million elements sorted / s |             |
 | chapel      | 6524                  | 138                  |
 | mpi         | 830                   | 412                  |
-| shmem       | 1874                  | 295                  |
+| shmem       | 1883                  | 295                  |
 
 PRs contributing improved versions or implementations in other
 distributed-memory parallel programming frameworks are welcome!

--- a/shmem/README.md
+++ b/shmem/README.md
@@ -41,30 +41,30 @@ Performance was measured on an HPE Cray Supercomputing EX using 64 nodes
 Compile command:
 
 ```
-CC -O3 shmem_lsbsort.cpp -o shmem_lsbsort -I pcg-cpp/include/
+CC -O3 -DNDEBUG shmem_lsbsort.cpp -o shmem_lsbsort -I pcg-cpp/include/
 ```
 
 Run command:
 
 ```
-srun --nodes 64 --ntasks-per-node=128 ./shmem_lsbsort --n 68719476736
+srun --nodes 64 --ntasks-per-node=128 --hint=nomultithread ./shmem_lsbsort --n 68719476736
 ```
 
 Output:
 
 ```
-Total number of MPI ranks: 8192
+Total number of shmem PEs: 8192
 Problem size: 68719476736
 Generating random values
-Generated random values in 0.239003 s
+Generated random values in 0.220942 s
 Sorting
-Sorted 68719476736 values in 82.7494
-That's 830.453 M elements sorted / s
+Sorted 68719476736 values in 36.476
+That's 1883.97 M elements sorted / s
 ```
 
 Other details:
- * used `PrgEnv-gnu` and `gcc-native/12.3`
- * used `cray-mpich/8.1.28`
+ * used `PrgEnv-gnu` and `gcc-native/14.2`
+ * used `cray-openshmemx/11.7.4`
  * used these additional environment variables
    ```
    export SLURM_UNBUFFEREDIO=1

--- a/shmem/shmem_lsbsort.cpp
+++ b/shmem/shmem_lsbsort.cpp
@@ -17,7 +17,7 @@
 #define RADIX 16
 #define N_DIGITS (64/RADIX)
 #define N_BUCKETS (1 << RADIX)
-#define COUNTS_SIZE (N_BUCKETS)
+#define COUNTS_SIZE ((int64_t) N_BUCKETS)
 #define MASK (N_BUCKETS - 1)
 using counts_array_t = std::array<int64_t, COUNTS_SIZE>;
 


### PR DESCRIPTION
Replace what looks like MPI output with the right SHMEM output in the README.

This also fixes in `int` overflow seen at scale for the `COUNTS_SIZE*numRanks` in the global counts/starts creation.